### PR TITLE
Add per-tweak world-blacklist option

### DIFF
--- a/common/src/main/java/me/colingrimes/tweaky/config/implementation/Settings.java
+++ b/common/src/main/java/me/colingrimes/tweaky/config/implementation/Settings.java
@@ -82,4 +82,28 @@ public class Settings extends Configuration {
 
 		return hasPath(nestedPath) ? option(nestedPath) : option(defPath);
 	}
+
+	/**
+	 * Gets the world blacklist for the specified tweak ID.
+	 * <p>
+	 * A tweak will not run in any world contained in its blacklist.
+	 * World names are lowercased so the comparison is case-insensitive.
+	 *
+	 * @param id the tweak ID
+	 * @return the option holding the (possibly empty) set of blacklisted world names
+	 */
+	@Nonnull
+	public Option<Set<String>> getWorldBlacklist(@Nonnull String id) {
+		String section = "tweaks." + id.toLowerCase().replace("_", "-");
+		String path = section + ".world-blacklist";
+
+		Optional<Option<Set<String>>> existing = getOption(path);
+		if (existing.isPresent()) {
+			return existing.get();
+		}
+
+		return option(path, section, sec -> sec == null ? Set.of() : sec.getStringList("world-blacklist").stream()
+				.map(String::toLowerCase)
+				.collect(Collectors.toSet()));
+	}
 }

--- a/common/src/main/java/me/colingrimes/tweaky/tweak/event/TweakEvent.java
+++ b/common/src/main/java/me/colingrimes/tweaky/tweak/event/TweakEvent.java
@@ -86,6 +86,10 @@ public final class TweakEvent {
 	 */
 	private static boolean ignoreEvent(@Nonnull Tweak tweak, @Nonnull Event event) {
 		TweakProperties properties = tweak.getProperties();
+		if (properties.isWorldBlacklisted(Events.getWorld(event))) {
+			return true;
+		}
+
 		return !tweak.hasPermission(Events.getPlayer(event)) || properties.getGuard().reject(event);
 	}
 }

--- a/common/src/main/java/me/colingrimes/tweaky/tweak/properties/TweakProperties.java
+++ b/common/src/main/java/me/colingrimes/tweaky/tweak/properties/TweakProperties.java
@@ -1,10 +1,15 @@
 package me.colingrimes.tweaky.tweak.properties;
 
+import me.colingrimes.tweaky.config.Option;
+import me.colingrimes.tweaky.config.manager.ConfigurationProvider;
 import me.colingrimes.tweaky.menu.tweak.TweakMenu;
 import me.colingrimes.tweaky.tweak.event.TweakHandler;
 import me.colingrimes.tweaky.util.bukkit.Events;
+import org.bukkit.World;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Set;
 
 /**
  * Contains the various properties of a tweak.
@@ -20,6 +25,16 @@ public class TweakProperties {
 	private final Events.Guard guard = Events.guard();
 	private TweakCategory category = TweakCategory.UNKNOWN;
 	private boolean permissionRequired = true;
+	private Option<Set<String>> worldBlacklist = new Option<>() {
+		@Nonnull
+		@Override
+		public Set<String> get() {
+			return Set.of();
+		}
+
+		@Override
+		public void reload(@Nullable ConfigurationProvider provider) {}
+	};
 
 	/**
 	 * Gets the {@link Events.Guard} used to pre-filter all listeners of the tweak.
@@ -48,6 +63,30 @@ public class TweakProperties {
 	@Nonnull
 	public TweakCategory getCategory() {
 		return category;
+	}
+
+	/**
+	 * Sets the world blacklist option for the tweak.
+	 *
+	 * @param worldBlacklist the option holding the blacklisted world names
+	 */
+	public void setWorldBlacklist(@Nonnull Option<Set<String>> worldBlacklist) {
+		this.worldBlacklist = worldBlacklist;
+	}
+
+	/**
+	 * Checks whether the tweak is blacklisted in the given world.
+	 *
+	 * @param world the world to check (may be null if unknown)
+	 * @return true if the tweak should not run in the world
+	 */
+	public boolean isWorldBlacklisted(@Nullable World world) {
+		if (world == null) {
+			return false;
+		}
+
+		Set<String> blacklist = worldBlacklist.get();
+		return !blacklist.isEmpty() && blacklist.contains(world.getName().toLowerCase());
 	}
 
 	/**

--- a/common/src/main/java/me/colingrimes/tweaky/tweak/type/DefaultTweak.java
+++ b/common/src/main/java/me/colingrimes/tweaky/tweak/type/DefaultTweak.java
@@ -29,6 +29,7 @@ public abstract class DefaultTweak implements Tweak {
 		this.id = id;
 		this.properties = new TweakProperties();
 		this.configureProperties(properties);
+		this.properties.setWorldBlacklist(settings.getWorldBlacklist(id));
 	}
 
 	/**

--- a/common/src/main/java/me/colingrimes/tweaky/util/bukkit/Events.java
+++ b/common/src/main/java/me/colingrimes/tweaky/util/bukkit/Events.java
@@ -5,6 +5,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Keyed;
 import org.bukkit.Material;
 import org.bukkit.Tag;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
@@ -150,6 +151,35 @@ public final class Events {
 			case EntityEvent e -> e.getEntity();
 			default -> null;
 		};
+	}
+
+	/**
+	 * Attempts to get the world associated with the event.
+	 * <p>
+	 * The world is resolved from the relevant block, entity, or player,
+	 * in that order of preference.
+	 *
+	 * @param event the event
+	 * @return the world if available
+	 */
+	@Nullable
+	public static World getWorld(@Nonnull Event event) {
+		Block block = getBlock(event);
+		if (block != null) {
+			return block.getWorld();
+		}
+
+		Entity entity = getEntity(event);
+		if (entity != null) {
+			return entity.getWorld();
+		}
+
+		Player player = getPlayer(event);
+		if (player != null) {
+			return player.getWorld();
+		}
+
+		return null;
 	}
 
 	/**

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -168,7 +168,13 @@ tweaks:
     # 50% = If you have 64 cobblestone, you will keep 32 of it.
     stackables: 0%
   # Allows you to place ladders up/down depending on your direction by right-clicking existing ladders.
-  ladder-placement: false
+  ladder-placement:
+    toggle: false
+    # Any tweak can be disabled in specific worlds by adding a "world-blacklist".
+    # The tweak runs on the whole server EXCEPT for the worlds listed here.
+    # World names are case-insensitive. Leave empty (or remove) to run everywhere.
+    world-blacklist: []
+    # - duels
   # Allows you to instantly climb up/down ladders.
   ladder-teleportation:
     toggle: false


### PR DESCRIPTION
Closes #4.

## What

Adds an optional `world-blacklist` to any tweak. The tweak runs on the entire server **except** for the worlds listed:

```yaml
tweaks:
  ladder-placement:
    toggle: true
    world-blacklist:
      - duels
```

World names are matched case-insensitively. An empty/missing list keeps the current behaviour (runs everywhere), so this is fully backwards-compatible — existing configs using `tweak: true` are untouched.

## How

The check is added to the single existing funnel `TweakEvent#ignoreEvent`, right next to the permission and `Guard` checks, so it applies to **every** tweak that uses `@TweakHandler` without touching each tweak class:

- `Events#getWorld(Event)` — resolves the world from the event's block, entity, or player (in that order).
- `TweakProperties` — holds an `Option<Set<String>>` blacklist and exposes `isWorldBlacklisted(World)`.
- `Settings#getWorldBlacklist(id)` — lazily registers the option per tweak, mirroring the existing `getTweak(id)` pattern, so it reloads via `/tweaky reload`.
- `DefaultTweak` — wires the option in once in its constructor.

## Notes / limitations

- Only tweaks whose handlers use `@TweakHandler` are covered (they all flow through `ignoreEvent`). Handlers using a plain `@EventHandler` bypass the funnel and would not be filtered — happy to extend coverage there if you'd prefer.
- I kept the design generic on purpose (one central check) rather than a per-tweak `allowed-worlds` like `break-bedrock`, but I'm glad to align it to whatever convention you prefer.

Built and tested locally against a Paper server: the tweak is correctly disabled in blacklisted worlds and active elsewhere, and the list updates on reload.
